### PR TITLE
Skip non-existing target hashes

### DIFF
--- a/src/js/gumshoe.js
+++ b/src/js/gumshoe.js
@@ -188,9 +188,11 @@
 		// For each link, create an object of attributes and push to an array
 		forEach( navLinks, function (nav) {
 			if ( !nav.hash ) return;
+			var target = document.querySelector( nav.hash );
+			if ( !target ) return;
 			navs.push({
 				nav: nav,
-				target: document.querySelector( nav.hash ),
+				target: target,
 				parent: nav.parentNode.tagName.toLowerCase() === 'li' ? nav.parentNode : null,
 				distance: 0
 			});


### PR DESCRIPTION
When the selector contains a link with an hash that doesn't have a target (on the same page), the `getOffsetTop` function is called with `null` as argument for `elem` and throws an error.

The selector could of course be more specific (to exclude the links without targets), but I think it's safe to exclude them anyway.