### PR TITLE
Use document.getElementById() for target elements

### DIFF
--- a/src/js/gumshoe.js
+++ b/src/js/gumshoe.js
@@ -192,7 +192,7 @@
 			if ( !nav.hash ) return;
 			navs.push({
 				nav: nav,
-				target: document.querySelector( nav.hash ),
+				target: document.getElementById( nav.hash.substr( 1 ) ),
 				parent: nav.parentNode.tagName.toLowerCase() === 'li' ? nav.parentNode : null,
 				distance: 0
 			});


### PR DESCRIPTION
Using `document.querySelector( nav.hash )` can result in invalid selectors for [perfectly valid ids](https://www.w3.org/TR/html5/dom.html#the-id-attribute). This change derives the id from the hash by chopping off the `#` and passing it to `document.getElementById()`.