### PR TITLE
Fix JS syntax in README global settings example

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ You can pass options and callbacks into Gumshoe through the `init()` function:
 
 ```javascript
 gumshoe.init({
-	selector: '[data-gumshoe] a' // Default link selector (must use a valid CSS selector)
-	selectorHeader: '[data-gumshoe-header]' // Fixed header selector (must use a valid CSS selector)
+	selector: '[data-gumshoe] a', // Default link selector (must use a valid CSS selector)
+	selectorHeader: '[data-gumshoe-header]', // Fixed header selector (must use a valid CSS selector)
 	offset: 0, // Distance in pixels to offset calculations
 	activeClass: 'active', // Class to apply to active navigation link and it's parent list item
 	callback: function (nav) {} // Callback to run after setting active link


### PR DESCRIPTION
Hey hey,

this is just adding two commas in one of the README's snippets, after the end of the two first options:

```javascript
gumshoe.init({
	selector: '[data-gumshoe] a', // Default link selector (must use a valid CSS selector)
	selectorHeader: '[data-gumshoe-header]', // Fixed header selector (must use a valid CSS selector)
	offset: 0, // Distance in pixels to offset calculations
	activeClass: 'active', // Class to apply to active navigation link and it's parent list item
	callback: function (nav) {} // Callback to run after setting active link
});
```

Now this can just be copy/pasted :)