### PR TITLE
Improve offset calculations in example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,18 +143,12 @@ The `offset` user setting accepts either a number, or a function that returns a 
 Here's an example that automatically calculates a header's height and offsets by that amount.
 
 ```js
+// Get the header (once)
+var header = document.querySelector('#my-header');
+
 var spy = new Gumshoe('#my-awesome-nav a', {
 	offset: function () {
-
-		// Get the header
-		var header = document.querySelector('#my-header');
-
-		// Get its computed styles
-		var computed = window.getComputedStyle(header);
-
-		// Return the headers height + margins + padding
-		return parseFloat(computed.height) + parseFloat(computed.marginTop) + parseFloat(computed.marginBottom) + parseFloat(computed.paddingTop) + parseFloat(computed.paddingBottom);
-
+		return header.getBoundingClientRect().height;
 	}
 });
 ```


### PR DESCRIPTION
[getBoundingClientRect](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect) can directly determine the actual height of an element and 
is [supported in all modern browsers](https://caniuse.com/#feat=getboundingclientrect).

Also the fixed header element needs to be looked up only once at initialization 
(if the element somehow must change, which should be quite a rare use/design case, 
this can be adjusted in the example code).