### PR TITLE
Check a parentNode exists when deactivating nested hierarchies

### DIFF
--- a/src/js/gumshoe/gumshoe.js
+++ b/src/js/gumshoe/gumshoe.js
@@ -198,10 +198,10 @@
 	var deactivateNested = function (nav, settings) {
 
 		// If nesting isn't activated, bail
-		if (!settings.nested) return;
+		if (!settings.nested || !nav.parentNode) return;
 
 		// Get the parent navigation
-		var li = nav.parentNode && nav.parentNode.closest('li');
+		var li = nav.parentNode.closest('li');
 		if (!li) return;
 
 		// Remove the active class

--- a/src/js/gumshoe/gumshoe.js
+++ b/src/js/gumshoe/gumshoe.js
@@ -201,7 +201,7 @@
 		if (!settings.nested) return;
 
 		// Get the parent navigation
-		var li = nav.parentNode.closest('li');
+		var li = nav.parentNode && nav.parentNode.closest('li');
 		if (!li) return;
 
 		// Remove the active class


### PR DESCRIPTION
The `setup()` method fails with `Uncaught TypeError: Cannot read property 'closest' of null` when parent items in nested hierarchies have been removed from the DOM.

This pull request fixes the issue by checking for the existence of the parentNode before trying to find its children.