### PR TITLE
useLastItem() sometimes fails because item is undefined

### DIFF
--- a/src/js/gumshoe/gumshoe.js
+++ b/src/js/gumshoe/gumshoe.js
@@ -172,7 +172,7 @@
 	 * @return {Boolean}         If true, use the last item
 	 */
 	var useLastItem = function (item, settings) {
-		if (isAtBottom() && isInView(item.content, settings, true)) return true;
+		if (isAtBottom() && item && isInView(item.content, settings, true)) return true;
 		return false;
 	};
 


### PR DESCRIPTION
I noticed a bug where in certain situations it'd break with an error. It seems to happen when searching for a string which has one result, adding another character so there are zero results, and then backspacing that character.

Anyway, it looks like the item passed to useLastItem is sometimes undefined. I'm not sure if there might be a better way to fix the root cause further up, but this at least stop its from failing.